### PR TITLE
Fixed Firebase Warning auth is being deprecated

### DIFF
--- a/lib/connect-firebase.js
+++ b/lib/connect-firebase.js
@@ -1,6 +1,6 @@
 /*!
  * Connect - Firebase
- * Copyright(c) 2015 Mike Carson <ca98am79@gmail.com>
+ * Copyright(c) 2014 Mike Carson <ca98am79@gmail.com>
  * MIT Licensed
  */
 /**
@@ -33,32 +33,37 @@ module.exports = function (session) {
      * Initialize FirebaseStore with the given `options`.
      *
      * @param {Object} options
+     * @param {Function} fn
      * @api public
      */
 
-    function FirebaseStore(options) {
+    function FirebaseStore(options, fn) {
         options = options || {};
         Store.call(this, options);
 
         this.host = options.host;
         this.token = options.token;
         this.cleanSid = options.cleanSid || function (sid) {
-        	// Firebase does not allow certain characters
-        	//	see: https://www.firebase.com/docs/creating-references.html
+            // Firebase does not allow certain characters
+            //  see: https://www.firebase.com/docs/creating-references.html
             return sid.replace(/\.|#|\$|\[|\]/g, '_');
         };
 
         if (this.token) {
             var sessionRef = new Firebase('https://' + this.host);
-            sessionRef.auth(this.token);
+            sessionRef.authWithCustomToken(this.token, function(err){
+                if(err){
+                    fn(err);
+                }
+            });
         }
 
-        this.reapInterval = options.reapInterval || (oneDayInMilliseconds / 4)
+        this.reapInterval = options.reapInterval || (oneDayInMilliseconds / 4);
         if (this.reapInterval > 0) {
             setInterval(this.reap.bind(this), this.reapInterval);
         }
 
-	}
+    }
     /*
      *  Inherit from `Store`.
      */


### PR DESCRIPTION
I'm using this project with express and am receiving FIREBASE WARNING: FirebaseRef.auth() being deprecated. Please use FirebaseRef.authWithCustomToken() instead.  I updated the auth call to authWithCustomToken and added a call back to the FirebaseStore method.