### PR TITLE
Adding callback support for reapInterval via a reapCallback option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,6 +17,8 @@
   "strict": false,
   "trailing": true,
   "smarttabs": false,
+  "mocha": true,
+
 
   "-W030": true,
   "-W052": true,

--- a/lib/connect-firebase.js
+++ b/lib/connect-firebase.js
@@ -60,7 +60,7 @@ module.exports = function (session) {
 
         this.reapInterval = options.reapInterval || (oneDayInMilliseconds / 4);
         if (this.reapInterval > 0) {
-            setInterval(this.reap.bind(this), this.reapInterval);
+            setInterval(this.reap.bind(this, options.reapCallback), this.reapInterval);
         }
 
     }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "firebase": "*"
   },
   "devDependencies": {
+    "sinon": "*",
     "should": "*",
     "mocha": "*",
     "express-session": "*"

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var host = 'xxx.firebaseio.com';
 var authToken = 'xxxxx';
 
 var should = require('should'),
+    sinon = require('sinon'),
     session = require('express-session'),
     FirebaseStore = require(__dirname + '/../lib/connect-firebase.js')(session);
 
@@ -166,5 +167,28 @@ describe('FirebaseStore', function () {
             });
         });
 
+    });
+
+    describe('Reaping intervals', function () {
+        var spy;
+
+        before(function (done) {
+          var called = false;
+          spy = sinon.spy(function(err, res) {
+            if(called === false) {
+              called = true;
+              done();
+            }
+          });
+          var store = new FirebaseStore({
+              host: host,
+              reapInterval: 100,
+              reapCallback: spy
+          });
+        });
+
+        it('should call the reap callback', function () {
+            spy.called.should.be.true;
+        });
     });
 });


### PR DESCRIPTION
This addresses issue #7.

I've added support for the option "reapCallback" that allows passing a callback method which is then passed to the reap method.

The reap method already implements calling back the callback with the removed list of session ids in case removal takes place.
